### PR TITLE
Add a console log to notify user the web root and port number to see …

### DIFF
--- a/start.js
+++ b/start.js
@@ -23,6 +23,9 @@ app.locals.assetPath = '/';
 app.locals.localAssets = '/';
 app.locals.isDev = app.get('env') === 'development';
 
+var webPort;
+webPort = process.env.PORT || 3000;
+
 app.use(favicon(
   path.join(__dirname, 'global', 'public', 'images', 'favicon.ico')));
 
@@ -110,4 +113,6 @@ if (app.locals.isDev) {
 // global controllers
 require('./lib/controllers/index.js')(app);
 
-app.listen(process.env.PORT || 3000);
+app.listen(webPort);
+
+console.log("Starting express web server http://localhost:" + webPort);


### PR DESCRIPTION
…the prototype in the browser.

Pull request to resolve issue #37
Once gulp is run add a helpful message in the terminal showing prototype URL